### PR TITLE
4.0.2-hotfix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,14 @@ FROM crazymax/rtorrent-rutorrent:latest
 LABEL maintainer="XxAcielxX"
 LABEL org.opencontainers.image.vendor="XxAcielxX"
 LABEL org.opencontainers.image.title="ruTorrent"
-LABEL org.opencontainers.image.description="rTorrent and ruTorrent Docker based container"
+LABEL org.opencontainers.image.description="rTorrent and ruTorrent Docker based image"
 LABEL org.opencontainers.image.url="https://hub.docker.com/r/xxacielxx/rutorrent"
 LABEL org.opencontainers.image.source="https://github.com/XxAcielxX/docker-rutorrent"
 
 # modifications
 RUN \
   echo "**** apply patches for /downloads ****" && \
-  sed -i -e '146s/themes [*\]/themes/; 233s_[*/]_/downloads_; 147,148d;378,379d' '/etc/cont-init.d/03-config.sh' && \
+  sed -i -e '146s/themes [*\]/themes/; 236s_[*/]_/downloads_; 147,148d;381,382d' '/etc/cont-init.d/03-config.sh' && \
   sed -i -e '5,23s/[*/]complete//' '/tpls/etc/nginx/conf.d/webdav.conf' && \
   sed -i -e '/pex\.set/s/yes/no/; /umask\.set/s/^/#/; 56,63d' '/tpls/.rtorrent.rc' && \
   sed -i -e '/complete\//d; /temp\//d; /directory\.default/s/download_temp/download/' '/tpls/etc/rtorrent/.rtlocal.rc'


### PR DESCRIPTION
`$cachedPluginLoading` should be set to `false`, as It is not stable yet ([218](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/218))