### PR TITLE
4.2.9-a03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * rTorrent: tracker scrape feature patch ([288](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/288))
 * Alpine Linux 3.19 and PHP 8.2 ([297](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/297))
 * cURL 8.5.0, c-ares 1.24.0 ([295](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/295))
+* UDNS support ([303](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/303))
 
 ## v4.2.9-a02
 ### Base Image:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v4.2.9-a03
+### Base Image:
+* rTorrent: tracker scrape feature patch ([288](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/288))
+* Alpine Linux 3.19 and PHP 8.2 ([297](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/297))
+* cURL 8.5.0, c-ares 1.24.0 ([295](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/295))
+
 ## v4.2.9-a02
 ### Base Image:
 * rTorrent patches

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source="https://github.com/XxAcielxX/docker-rutor
 # modifications
 RUN \
   echo "**** apply patches for /downloads ****" && \
-  sed -i -e '149s/themes [*\]/themes/; 241s_[*/]_/downloads_; 150,151d;386,387d' '/etc/cont-init.d/03-config.sh' && \
+  sed -i -e '150s/themes [*\]/themes/; 242s_[*/]_/downloads_; 151,152d;387,388d' '/etc/cont-init.d/03-config.sh' && \
   sed -i -e '5,23s/[*/]complete//' '/tpls/etc/nginx/conf.d/webdav.conf' && \
   sed -i -e '/pex\.set/s/yes/no/; /umask\.set/s/^/#/; 56,60d' '/tpls/.rtorrent.rc' && \
   sed -i -e '/complete\//d; /temp\//d; /directory\.default/s/download_temp/download/' '/tpls/etc/rtorrent/.rtlocal.rc'


### PR DESCRIPTION
## Base Image:
* rTorrent: tracker scrape feature patch ([288](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/288))
* Alpine Linux 3.19 and PHP 8.2 ([297](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/297))
* cURL 8.5.0, c-ares 1.24.0 ([295](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/295))
* UDNS support ([303](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/303))