### PR TITLE
4.3.0-a01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ LABEL org.opencontainers.image.source="https://github.com/XxAcielxX/docker-rutor
 # modifications
 RUN \
   echo "**** apply patches for /downloads ****" && \
-  sed -i -e '150s/themes [*\]/themes/; 242s_[*/]_/downloads_; 151,152d;387,388d' '/etc/cont-init.d/03-config.sh' && \
+  sed -i -e '152s/themes [*\]/themes/; 247s_[*/]_/downloads_; 153,154d;392,393d' '/etc/cont-init.d/03-config.sh' && \
   sed -i -e '5,23s/[*/]complete//' '/tpls/etc/nginx/conf.d/webdav.conf' && \
   sed -i -e '/pex\.set/s/yes/no/; /umask\.set/s/^/#/; 56,60d' '/tpls/.rtorrent.rc' && \
   sed -i -e '/complete\//d; /temp\//d; /directory\.default/s/download_temp/download/' '/tpls/etc/rtorrent/.rtlocal.rc'


### PR DESCRIPTION
## Changes:
* Update to `ruTorrent v4.3.0`

## Base Image:
* rTorrent: Add TCP socket configurations ([322](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/322))
* Add php82-fileinfo package ([325](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/325))
* rTorrent: Set of patches to fix memory leaks ([308](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/308))
* rTorrent: Fix memory access crash ([310](https://github.com/crazy-max/docker-rtorrent-rutorrent/pull/310))